### PR TITLE
Fix chat message parsing to support player names with colons

### DIFF
--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -3,7 +3,7 @@
     "logPath": "C:/Program Files (x86)/Steam/steamapps/common/Left 4 Dead 2/left4dead2/console.log",
     "pollInterval": 1000,
     "messageFormat": {
-      "regex": "^\\((Survivor|Infected)\\)\\s*(?:C\\s*\\(Infected\\)\\s*)?([^:]+?)\\s*:\\s*(.+)$|^([^:]+?)\\s*:\\s*(.+)$",
+      "regex": "^\\((Survivor|Infected)\\)\\s*(?:C\\s*\\(Infected\\)\\s*)?(.+?)\\s+:\\s+(.+)$|^(.+?)\\s+:\\s+(.+)$",
       "groups": {
         "team": 1,
         "player": "2,4",

--- a/src/reader/message_reader.py
+++ b/src/reader/message_reader.py
@@ -115,7 +115,9 @@ class GameLogHandler(FileSystemEventHandler):
         # Chat messages have a specific format:
         # 1. Team chat: "(Survivor|Infected) ♥Name : message"
         # 2. Regular chat: "Name : message"
-        chat_pattern = r'^(?:\((Survivor|Infected)\)\s+)?[^:]+\s+:\s+.+'
+        # Use .+? (not [^:]+) so player names containing colons still match;
+        # the \s+:\s+ around the separator is what disambiguates name from message.
+        chat_pattern = r'^(?:\((Survivor|Infected)\)\s+)?.+?\s+:\s+.+'
         if re.match(chat_pattern, line):
             return False
                 


### PR DESCRIPTION
## Summary
Updated message parsing logic to correctly handle player names that contain colons, which were previously causing parsing failures.

## Key Changes
- **message_reader.py**: Modified the chat message regex pattern from `[^:]+` to `.+?` (non-greedy match) to allow colons in player names. The pattern now relies on the `\s+:\s+` separator to disambiguate between the player name and message content.
- **config.sample.json**: Updated the message format regex patterns to use `.+?` instead of `[^:]+?` for both team chat and regular chat formats, with consistent whitespace handling around the colon separator.

## Implementation Details
The key insight is that using a non-greedy match (`.+?`) combined with the explicit `\s+:\s+` separator pattern provides better disambiguation than trying to exclude colons from player names. This allows the regex to correctly identify the actual message separator even when player names contain colons, while the non-greedy quantifier ensures we match the shortest possible name before the separator.

https://claude.ai/code/session_01JF3Dr1CuH4Uyr6arKKJzuL