### PR TITLE
Add always-on-top translation overlay as a Turing-screen alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ This separation allows the display hardware logic to be reused in other projects
 
 ## Changelog
 
+### Unreleased
+- Added an **always-on-top translation overlay** — a software stand-in for the
+  Turing Smart Screen. Toggle it from the **Overlay** button in the GUI header.
+  It floats over a borderless/windowed game without stealing keyboard focus
+  (uses `WS_EX_NOACTIVATE` on Windows), is draggable/resizable, has adjustable
+  opacity, and mirrors the Turing screen's styling and colors.
+- Added a `screen.enabled` config flag (and a **Use hardware Turing screen**
+  toggle in Settings) so you can run with no Turing hardware at all — the engine
+  skips the serial connection and feeds translations to the overlay instead.
+
 ### v1.2.7
 - Refactored display module to separate reusable TuringDisplay library from Left4Translate-specific ScreenController
 - TuringDisplay now supports multiple hardware revisions (Rev A, B, C, D)
@@ -126,12 +136,39 @@ companion **l4d2gamefinder** app so the two tools feel like one product family.
 
 Run from source with: `python gui_main.py`
 
+#### On-screen overlay (no hardware needed)
+
+If you don't have a Turing Smart Screen — or just want the output on the same
+monitor as the game — click **Overlay** in the GUI header. This opens a small,
+always-on-top window that mirrors what would scroll across the Turing screen
+(player names, original text, and the green-arrow translation), styled the same
+way.
+
+- **Floats over the game without stealing focus.** Run Left 4 Dead 2 in
+  *borderless / windowed-fullscreen* mode and the overlay stays on top while
+  keyboard input keeps going to the game (on Windows it's marked
+  `WS_EX_NOACTIVATE`, so even clicking its title bar won't pull focus away).
+  *Note:* true **exclusive** fullscreen paints over all top-most windows, so use
+  borderless/windowed mode for the overlay to be visible.
+- **Draggable and resizable** — drag the title bar to move it, drag the
+  bottom-right corner to resize. Position, size, opacity, and whether it was open
+  are remembered between sessions.
+- The title bar has buttons to lower/raise opacity (`–` / `+`), clear messages
+  (`⌫`), and hide the overlay (`✕`).
+
+To run with **no Turing hardware at all**, uncheck **Use hardware Turing screen**
+under **Settings → Turing Screen** (or set `"screen": { "enabled": false }` in
+`config.json`). The engine then skips the serial connection entirely and feeds
+translations straight to the overlay / live feed.
+
 ## Requirements
 
 - Python 3.10 - 3.13 (Recommended: 3.11)
   - Note: Python 3.14+ is not yet fully supported as many dependencies do not have pre-built wheels, requiring a C++ compiler and Rust toolchain to build from source.
 - Left 4 Dead 2 (for chat translation feature)
-- Turing Smart Screen
+- Turing Smart Screen — **optional**. You can instead use the always-on-top
+  on-screen overlay (see [On-screen overlay](#on-screen-overlay-no-hardware-needed)).
+  To use the hardware screen:
     See here for compatible screen: https://www.aliexpress.com/item/1005003931363455.html
     See here for more info on screens: https://github.com/mathoudebine/turing-smart-screen-python
 - Google Cloud Authentication:

--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -20,6 +20,7 @@
     "retryAttempts": 3
   },
   "screen": {
+    "enabled": true,
     "port": "COM8",
     "baudRate": 115200,
     "brightness": 50,

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -22,6 +22,7 @@ from PySide6.QtWidgets import (
 from gui.dashboard_tab import DashboardTab
 from gui.engine_controller import EngineController
 from gui.logs_tab import LogsTab
+from gui.overlay_window import OverlayWindow
 from gui.settings_store import MODES, SettingsStore
 from gui.settings_tab import SettingsTab
 from gui.theme import apply_theme
@@ -64,10 +65,13 @@ class MainWindow(QMainWindow):
         self.setStatusBar(QStatusBar(self))
         self.statusBar().showMessage("Ready")
 
+        self._overlay = OverlayWindow(self._store)
+
         self._tray = self._build_tray()
         self._restore_geometry()
         self._wire_signals()
         self._set_ui_running(False)
+        self._restore_overlay()
 
     # ---- Construction ---------------------------------------------------
 
@@ -95,6 +99,16 @@ class MainWindow(QMainWindow):
         self._start_button.setObjectName("PrimaryButton")
         self._start_button.clicked.connect(self._toggle_engine)
         row.addWidget(self._start_button)
+
+        self._overlay_button = QPushButton("Overlay")
+        self._overlay_button.setCheckable(True)
+        self._overlay_button.setToolTip(
+            "Show an always-on-top translation overlay (a software stand-in for "
+            "the Turing screen). Floats over a borderless/windowed game without "
+            "stealing focus."
+        )
+        self._overlay_button.toggled.connect(self._toggle_overlay)
+        row.addWidget(self._overlay_button)
 
         row.addStretch(1)
 
@@ -167,6 +181,21 @@ class MainWindow(QMainWindow):
         self._show_status(f"Starting translation ({mode})…")
         self._controller.start(mode)
 
+    # ---- Overlay --------------------------------------------------------
+
+    def _restore_overlay(self) -> None:
+        """Re-open the overlay on launch if it was visible last session."""
+        if self._store.overlay_visible():
+            self._overlay_button.setChecked(True)
+
+    def _toggle_overlay(self, checked: bool) -> None:
+        if checked:
+            self._overlay.show()
+            self._overlay.raise_()
+        else:
+            self._overlay.hide()
+        self._store.set_overlay_visible(checked)
+
     def maybe_autostart(self) -> None:
         if self._store.autostart():
             self._toggle_engine()
@@ -183,6 +212,7 @@ class MainWindow(QMainWindow):
 
     def _on_translation(self, payload: dict) -> None:
         self.dashboard_tab.add_translation(payload)
+        self._overlay.add_translation(payload)
         if payload.get("kind") == "voice":
             self.voice_tab.add_voice_translation(payload)
 
@@ -265,6 +295,9 @@ class MainWindow(QMainWindow):
 
         self._store.set_geometry(self.saveGeometry())
         self._store.set_window_state(self.saveState())
+        if self._overlay.isVisible():
+            self._overlay.save_geometry()
+        self._overlay.close()
         self._controller.stop()
         self.logs_tab.detach()
         self.logs_tab.release_streams()

--- a/gui/overlay_window.py
+++ b/gui/overlay_window.py
@@ -1,0 +1,357 @@
+"""Always-on-top translation overlay — a software stand-in for the Turing screen.
+
+This frameless, semi-transparent window mirrors what would scroll across the
+Turing Smart Screen, so the app is useful with no hardware at all. It is built
+to float over a *borderless / windowed-fullscreen* game:
+
+* ``WindowStaysOnTopHint`` keeps it above the game window,
+* ``WA_ShowWithoutActivating`` (plus ``WS_EX_NOACTIVATE`` on Windows) means
+  showing it — and even clicking its drag bar — never pulls keyboard focus
+  away from Left 4 Dead 2.
+
+It consumes the same ``on_translation`` payloads the dashboard feed does, so the
+engine and its callbacks are completely unaware of it.
+
+Note: a game running in *exclusive* (true) fullscreen will paint over every
+top-most window, this one included. Run the game in borderless/windowed mode
+for the overlay to be visible.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import deque
+from html import escape
+from typing import Any, Deque, Dict, Optional
+
+from PySide6.QtCore import QPoint, Qt
+from PySide6.QtGui import QFont
+from PySide6.QtWidgets import (
+    QApplication,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSizeGrip,
+    QVBoxLayout,
+    QWidget,
+)
+
+from gui.settings_store import SettingsStore
+
+# Colors mirror ScreenController's Turing palette so the overlay reads the same.
+_PLAYER_COLOR = "#00BFFF"        # deep sky blue — regular chat names
+_TEAM_PLAYER_COLOR = "#FFA500"   # orange — team chat names
+_ORIGINAL_COLOR = "#FFFFFF"      # white — original text
+_ARROW_COLOR = "#32CD32"         # lime green — the "→" arrow
+_TRANSLATED_COLOR = "#90EE90"    # light green — translated text
+_VOICE_COLOR = "#b07cf0"         # purple — voice transcriptions
+
+_MAX_MESSAGES = 10               # rows kept on screen (newest on top)
+_MIN_OPACITY = 0.30
+_MAX_OPACITY = 1.0
+
+
+class _MessageLabel(QLabel):
+    """One translation rendered as rich text (player + original + translation)."""
+
+    def __init__(self, html: str, parent: Optional[QWidget] = None) -> None:
+        super().__init__(html, parent)
+        self.setObjectName("OverlayMessage")
+        self.setWordWrap(True)
+        self.setTextFormat(Qt.TextFormat.RichText)
+        self.setTextInteractionFlags(Qt.TextInteractionFlag.NoTextInteraction)
+
+
+class OverlayWindow(QWidget):
+    """Frameless, always-on-top mirror of the Turing screen output."""
+
+    def __init__(
+        self,
+        store: Optional[SettingsStore] = None,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+        # No Qt parent: a top-level tool window that floats independently of the
+        # main window (so it survives the main window being hidden to tray).
+        super().__init__(None)
+        self._store = store or SettingsStore()
+        self._messages: Deque[str] = deque(maxlen=_MAX_MESSAGES)
+        self._drag_offset: Optional[QPoint] = None
+        self._opacity = self._store.overlay_opacity()
+
+        self.setWindowTitle("Left4Translate Overlay")
+        self.setWindowFlags(
+            Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.WindowStaysOnTopHint
+            | Qt.WindowType.Tool
+        )
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        # Show without grabbing focus from the game.
+        self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating, True)
+        self.setMinimumSize(220, 120)
+
+        self._build_ui()
+        self._apply_opacity()
+        self._restore_geometry()
+
+    # ---- Construction ---------------------------------------------------
+
+    def _build_ui(self) -> None:
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+
+        self._panel = QFrame(self)
+        self._panel.setObjectName("OverlayPanel")
+        outer.addWidget(self._panel)
+
+        panel = QVBoxLayout(self._panel)
+        panel.setContentsMargins(2, 2, 2, 2)
+        panel.setSpacing(2)
+
+        panel.addWidget(self._build_title_bar())
+
+        self._body = QWidget(self._panel)
+        self._body.setObjectName("OverlayBody")
+        self._body_layout = QVBoxLayout(self._body)
+        self._body_layout.setContentsMargins(8, 6, 8, 6)
+        self._body_layout.setSpacing(5)
+        self._body_layout.addStretch(1)  # newest rows insert above this
+        panel.addWidget(self._body, stretch=1)
+
+        self._hint = QLabel("Waiting for translations…", self._body)
+        self._hint.setObjectName("OverlayHint")
+        self._body_layout.insertWidget(0, self._hint)
+
+        # Resize handle in the bottom-right corner.
+        grip_row = QHBoxLayout()
+        grip_row.setContentsMargins(0, 0, 2, 2)
+        grip_row.addStretch(1)
+        grip_row.addWidget(QSizeGrip(self._panel))
+        panel.addLayout(grip_row)
+
+        self._panel.setStyleSheet(self._panel_qss())
+
+    def _build_title_bar(self) -> QWidget:
+        bar = QWidget(self._panel)
+        bar.setObjectName("OverlayTitleBar")
+        bar.setFixedHeight(26)
+        # Dragging the bar moves the whole window.
+        bar.mousePressEvent = self._bar_mouse_press  # type: ignore[assignment]
+        bar.mouseMoveEvent = self._bar_mouse_move    # type: ignore[assignment]
+        bar.mouseReleaseEvent = self._bar_mouse_release  # type: ignore[assignment]
+
+        row = QHBoxLayout(bar)
+        row.setContentsMargins(8, 0, 4, 0)
+        row.setSpacing(4)
+
+        title = QLabel("Left4Translate", bar)
+        title.setObjectName("OverlayTitle")
+        row.addWidget(title)
+        row.addStretch(1)
+
+        less = self._tool_button("–", "Less opaque", self._decrease_opacity)
+        more = self._tool_button("+", "More opaque", self._increase_opacity)
+        clear = self._tool_button("⌫", "Clear messages", self.clear)
+        close = self._tool_button("✕", "Hide overlay", self.hide)
+        for btn in (less, more, clear, close):
+            row.addWidget(btn)
+        return bar
+
+    def _tool_button(self, text: str, tip: str, slot) -> QPushButton:
+        btn = QPushButton(text, self)
+        btn.setObjectName("OverlayToolButton")
+        btn.setFixedSize(20, 20)
+        btn.setToolTip(tip)
+        btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        btn.clicked.connect(slot)
+        return btn
+
+    # ---- Public API -----------------------------------------------------
+
+    def add_translation(self, payload: Dict[str, Any]) -> None:
+        """Render a translation row (newest on top), trimming old ones."""
+        kind = payload.get("kind", "chat")
+        player = str(payload.get("player") or "—")
+        original = str(payload.get("original") or "")
+        translated = str(payload.get("translated") or "")
+        team = payload.get("team")
+
+        if kind == "voice":
+            name_color = _VOICE_COLOR
+        elif team and str(team).lower().startswith(("surv", "inf")):
+            name_color = _TEAM_PLAYER_COLOR
+        else:
+            name_color = _PLAYER_COLOR
+
+        parts = [
+            f'<span style="color:{name_color}; font-weight:bold;">'
+            f'[{escape(player)}]</span> '
+            f'<span style="color:{_ORIGINAL_COLOR};">{escape(original)}</span>'
+        ]
+        if translated and translated != original:
+            parts.append(
+                f'<span style="color:{_ARROW_COLOR};">&#8594;</span> '
+                f'<span style="color:{_TRANSLATED_COLOR};">{escape(translated)}</span>'
+            )
+        html = "<br>".join(parts)
+
+        self._messages.append(html)
+        self._rebuild()
+
+    def clear(self) -> None:
+        """Remove all messages from the overlay."""
+        self._messages.clear()
+        self._rebuild()
+
+    # ---- Rendering ------------------------------------------------------
+
+    def _rebuild(self) -> None:
+        # Drop existing message labels (keep the leading hint + trailing stretch).
+        for i in reversed(range(self._body_layout.count())):
+            item = self._body_layout.itemAt(i)
+            widget = item.widget()
+            if isinstance(widget, _MessageLabel):
+                widget.setParent(None)
+                widget.deleteLater()
+
+        self._hint.setVisible(not self._messages)
+
+        # Insert newest first so it appears at the top of the body.
+        for html in reversed(self._messages):
+            label = _MessageLabel(html, self._body)
+            self._body_layout.insertWidget(0, label)
+
+    # ---- Opacity --------------------------------------------------------
+
+    def _apply_opacity(self) -> None:
+        self.setWindowOpacity(self._opacity)
+
+    def _increase_opacity(self) -> None:
+        self._set_opacity(self._opacity + 0.1)
+
+    def _decrease_opacity(self) -> None:
+        self._set_opacity(self._opacity - 0.1)
+
+    def _set_opacity(self, value: float) -> None:
+        self._opacity = max(_MIN_OPACITY, min(_MAX_OPACITY, round(value, 2)))
+        self._apply_opacity()
+        self._store.set_overlay_opacity(self._opacity)
+
+    # ---- Dragging -------------------------------------------------------
+
+    def _bar_mouse_press(self, event) -> None:
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._drag_offset = (
+                event.globalPosition().toPoint() - self.frameGeometry().topLeft()
+            )
+            event.accept()
+
+    def _bar_mouse_move(self, event) -> None:
+        if self._drag_offset is not None and (event.buttons() & Qt.MouseButton.LeftButton):
+            self.move(event.globalPosition().toPoint() - self._drag_offset)
+            event.accept()
+
+    def _bar_mouse_release(self, event) -> None:
+        self._drag_offset = None
+        event.accept()
+
+    # ---- Geometry persistence -------------------------------------------
+
+    def _restore_geometry(self) -> None:
+        geometry = self._store.overlay_geometry()
+        if geometry is not None and self.restoreGeometry(geometry):
+            return
+        # Default: a compact strip near the top-left of the primary screen.
+        self.resize(420, 260)
+        screen = QApplication.primaryScreen()
+        if screen is not None:
+            available = screen.availableGeometry()
+            self.move(available.left() + 24, available.top() + 24)
+
+    def save_geometry(self) -> None:
+        self._store.set_overlay_geometry(self.saveGeometry())
+
+    # ---- Window events --------------------------------------------------
+
+    def showEvent(self, event) -> None:  # type: ignore[override]
+        super().showEvent(event)
+        self._apply_no_activate()
+        self.raise_()
+
+    def hideEvent(self, event) -> None:  # type: ignore[override]
+        self.save_geometry()
+        super().hideEvent(event)
+
+    def _apply_no_activate(self) -> None:
+        """On Windows, mark the window WS_EX_NOACTIVATE so it never takes focus.
+
+        ``WA_ShowWithoutActivating`` stops the initial show from stealing focus,
+        but a click on the drag bar would otherwise activate the window and pull
+        focus out of the game. The extended style makes the window unfocusable.
+        """
+        if sys.platform != "win32":
+            return
+        try:
+            import ctypes
+
+            GWL_EXSTYLE = -20
+            WS_EX_NOACTIVATE = 0x08000000
+            WS_EX_TOOLWINDOW = 0x00000080
+            hwnd = int(self.winId())
+            user32 = ctypes.windll.user32
+            current = user32.GetWindowLongW(hwnd, GWL_EXSTYLE)
+            user32.SetWindowLongW(
+                hwnd, GWL_EXSTYLE, current | WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW
+            )
+        except Exception:
+            # Best-effort: WA_ShowWithoutActivating still covers the common path.
+            pass
+
+    # ---- Styling --------------------------------------------------------
+
+    def _panel_qss(self) -> str:
+        return """
+        QFrame#OverlayPanel {
+            background: rgba(8, 8, 10, 235);
+            border: 1px solid rgba(224, 90, 43, 200);
+            border-radius: 10px;
+        }
+        QWidget#OverlayTitleBar {
+            background: rgba(26, 26, 31, 230);
+            border-top-left-radius: 9px;
+            border-top-right-radius: 9px;
+        }
+        QLabel#OverlayTitle {
+            color: #e05a2b;
+            font-weight: 700;
+            font-size: 11px;
+            background: transparent;
+        }
+        QWidget#OverlayBody { background: transparent; }
+        QLabel#OverlayMessage {
+            color: #ffffff;
+            background: transparent;
+            font-family: "Consolas", "Roboto Mono", monospace;
+            font-size: 13px;
+        }
+        QLabel#OverlayHint {
+            color: #8888a0;
+            background: transparent;
+            font-size: 12px;
+            font-style: italic;
+        }
+        QPushButton#OverlayToolButton {
+            background: rgba(255, 255, 255, 18);
+            color: #c8c8d4;
+            border: none;
+            border-radius: 4px;
+            font-weight: 700;
+            font-size: 12px;
+            padding: 0;
+        }
+        QPushButton#OverlayToolButton:hover {
+            background: rgba(224, 90, 43, 180);
+            color: white;
+        }
+        """

--- a/gui/settings_store.py
+++ b/gui/settings_store.py
@@ -41,12 +41,17 @@ class SettingsStore:
     KEY_START_MINIMIZED = "tray/start_minimized"
     KEY_GEOMETRY = "window/geometry"
     KEY_WINDOW_STATE = "window/state"
+    KEY_OVERLAY_VISIBLE = "overlay/visible"
+    KEY_OVERLAY_GEOMETRY = "overlay/geometry"
+    KEY_OVERLAY_OPACITY = "overlay/opacity"
 
     DEFAULT_THEME = THEME_DARK
     DEFAULT_MODE = "both"
     DEFAULT_AUTOSTART = True
     DEFAULT_MINIMIZE_TO_TRAY = True
     DEFAULT_START_MINIMIZED = False
+    DEFAULT_OVERLAY_VISIBLE = False
+    DEFAULT_OVERLAY_OPACITY = 0.9
 
     def __init__(self, qsettings: Optional[QSettings] = None) -> None:
         self._settings = qsettings if qsettings is not None else QSettings()
@@ -121,3 +126,31 @@ class SettingsStore:
 
     def set_window_state(self, value: QByteArray) -> None:
         self._settings.setValue(self.KEY_WINDOW_STATE, value)
+
+    # ---- Overlay window -------------------------------------------------
+
+    def overlay_visible(self) -> bool:
+        return _coerce_bool(
+            self._settings.value(self.KEY_OVERLAY_VISIBLE, self.DEFAULT_OVERLAY_VISIBLE),
+            self.DEFAULT_OVERLAY_VISIBLE,
+        )
+
+    def set_overlay_visible(self, value: bool) -> None:
+        self._settings.setValue(self.KEY_OVERLAY_VISIBLE, bool(value))
+
+    def overlay_geometry(self) -> Optional[QByteArray]:
+        value = self._settings.value(self.KEY_OVERLAY_GEOMETRY)
+        return value if isinstance(value, QByteArray) and not value.isEmpty() else None
+
+    def set_overlay_geometry(self, value: QByteArray) -> None:
+        self._settings.setValue(self.KEY_OVERLAY_GEOMETRY, value)
+
+    def overlay_opacity(self) -> float:
+        try:
+            value = float(self._settings.value(self.KEY_OVERLAY_OPACITY, self.DEFAULT_OVERLAY_OPACITY))
+        except (TypeError, ValueError):
+            return self.DEFAULT_OVERLAY_OPACITY
+        return min(1.0, max(0.3, value))
+
+    def set_overlay_opacity(self, value: float) -> None:
+        self._settings.setValue(self.KEY_OVERLAY_OPACITY, float(value))

--- a/gui/settings_tab.py
+++ b/gui/settings_tab.py
@@ -50,6 +50,7 @@ _FIELDS: List[Tuple[str, str]] = [
     ("translation.targetLanguage", "text"),
     ("translation.cacheSize", "int"),
     ("translation.rateLimitPerMinute", "int"),
+    ("screen.enabled", "bool"),
     ("screen.port", "text"),
     ("screen.baudRate", "int"),
     ("screen.brightness", "int"),
@@ -136,6 +137,7 @@ class SettingsTab(QWidget):
             ("translation.rateLimitPerMinute", "Rate limit / min", "int:1:100000"),
         ]))
         self._form_root.addWidget(self._group("Turing Screen", [
+            ("screen.enabled", "Use hardware Turing screen (uncheck to use the overlay only)", "bool"),
             ("screen.port", "Serial port", "text"),
             ("screen.baudRate", "Baud rate", "int:9600:1000000"),
             ("screen.brightness", "Brightness", "int:0:100"),
@@ -298,6 +300,10 @@ class SettingsTab(QWidget):
             if widget is None:
                 continue
             value = _dig(self._raw, path)
+            # screen.enabled is new: absent in older configs means "on", so the
+            # hardware screen isn't silently disabled on the next Save.
+            if value is None and path == "screen.enabled":
+                value = True
             self._set_widget_value(widget, kind, value)
 
     def save(self) -> None:

--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -27,6 +27,7 @@ class ScreenConfig:
     brightness: int
     refresh_rate: int
     display: Dict[str, Any]
+    enabled: bool = True
 
 @dataclass
 class LoggingConfig:
@@ -132,7 +133,8 @@ class ConfigManager:
             baud_rate=config.get("baudRate", 115200),
             brightness=config.get("brightness", 80),
             refresh_rate=config.get("refreshRate", 1000),
-            display=config.get("display", {})
+            display=config.get("display", {}),
+            enabled=config.get("enabled", True)
         )
         
     def get_logging_config(self) -> LoggingConfig:

--- a/src/main.py
+++ b/src/main.py
@@ -178,6 +178,11 @@ class Left4Translate:
                 retry_attempts=trans_config.retry_attempts
             )
             
+            # Whether the physical Turing Smart Screen is in use. When disabled,
+            # the engine skips the serial connection entirely — translations are
+            # still logged and surfaced to observers (e.g. the GUI overlay).
+            self.screen_enabled = getattr(screen_config, "enabled", True)
+
             # Initialize screen controller
             self.screen = ScreenController(
                 port=screen_config.port,
@@ -298,8 +303,11 @@ class Left4Translate:
             self.running = True
             self._emit_status("engine", "running")
 
-            # Connect to screen
-            if not self.screen.connect():
+            # Connect to screen (unless the hardware screen is disabled in config)
+            if not self.screen_enabled:
+                self.logger.info("Turing screen disabled in config - skipping hardware connection")
+                self._emit_status("screen", "disconnected", "Screen disabled")
+            elif not self.screen.connect():
                 self.logger.error("Failed to connect to screen")
                 # Graceful degradation: continue running without screen
                 self.logger.warning("Continuing without screen - translations will be logged but not displayed")
@@ -351,8 +359,9 @@ class Left4Translate:
                 
             if self.voice_manager:
                 self.voice_manager.stop()
-                
-            self.screen.disconnect()
+
+            if self.screen_enabled:
+                self.screen.disconnect()
 
             self.logger.info("Left4Translate stopped")
             self._emit_status("screen", "disconnected")

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -113,3 +113,76 @@ def test_engine_controller_status_signal(app):
     controller._on_status("screen", "connected", "")
     controller._on_translation({"kind": "chat", "original": "x", "translated": "y"})
     assert ("screen", "connected", "") in received
+
+
+# ---- Overlay window -------------------------------------------------------
+
+def _count_overlay_messages(overlay) -> int:
+    from gui.overlay_window import _MessageLabel
+
+    return sum(
+        1
+        for i in range(overlay._body_layout.count())
+        if isinstance(overlay._body_layout.itemAt(i).widget(), _MessageLabel)
+    )
+
+
+def test_overlay_add_and_clear(app, tmp_path):
+    from gui.overlay_window import OverlayWindow
+    from gui.settings_store import SettingsStore
+
+    store = SettingsStore(QSettings(str(tmp_path / "p.ini"), QSettings.Format.IniFormat))
+    overlay = OverlayWindow(store)
+
+    overlay.add_translation({"kind": "chat", "player": "Bob", "original": "hola",
+                             "translated": "hi", "team": "Survivor"})
+    overlay.add_translation({"kind": "voice", "player": "Voice", "original": "uno",
+                             "translated": "one", "team": None})
+    assert _count_overlay_messages(overlay) == 2
+    assert overlay._hint.isVisibleTo(overlay) is False
+
+    overlay.clear()
+    assert _count_overlay_messages(overlay) == 0
+    assert overlay._hint.isVisibleTo(overlay) is True
+
+
+def test_overlay_trims_to_max(app, tmp_path):
+    from gui.overlay_window import _MAX_MESSAGES, OverlayWindow
+    from gui.settings_store import SettingsStore
+
+    store = SettingsStore(QSettings(str(tmp_path / "p.ini"), QSettings.Format.IniFormat))
+    overlay = OverlayWindow(store)
+    for i in range(_MAX_MESSAGES + 5):
+        overlay.add_translation({"kind": "chat", "player": f"P{i}",
+                                 "original": str(i), "translated": str(i), "team": None})
+    assert _count_overlay_messages(overlay) == _MAX_MESSAGES
+
+
+def test_overlay_opacity_persists(app, tmp_path):
+    from gui.overlay_window import OverlayWindow
+    from gui.settings_store import SettingsStore
+
+    settings = QSettings(str(tmp_path / "p.ini"), QSettings.Format.IniFormat)
+    store = SettingsStore(settings)
+    overlay = OverlayWindow(store)
+    start = overlay._opacity
+    overlay._decrease_opacity()
+    assert overlay._opacity < start
+    # Persisted to the store so a new overlay restores it.
+    assert SettingsStore(settings).overlay_opacity() == overlay._opacity
+
+
+def test_settings_screen_enabled_defaults_on_when_absent(app, tmp_path):
+    from gui.settings_store import SettingsStore
+    from gui.settings_tab import SettingsTab
+
+    store = SettingsStore(QSettings(str(tmp_path / "prefs.ini"), QSettings.Format.IniFormat))
+    cfg = tmp_path / "config.json"
+    # An older config with no screen.enabled key.
+    cfg.write_text(json.dumps({"screen": {"port": "COM8"}}))
+
+    tab = SettingsTab(str(cfg), store)
+    # Absent should load as enabled, so a Save won't disable the hardware screen.
+    assert tab._widgets["screen.enabled"].isChecked() is True
+    tab.save()
+    assert json.loads(cfg.read_text())["screen"]["enabled"] is True


### PR DESCRIPTION
## Summary

Adds an optional **always-on-top translation overlay** to the desktop GUI — a software stand-in for the Turing Smart Screen — so Left4Translate is fully usable with no display hardware. The overlay floats over a borderless/windowed game **without stealing keyboard focus**, and a new `screen.enabled` flag lets you run with no Turing hardware connected at all.

Motivation: run L4D2 in a fullscreen window and get the Turing-style output as an always-on-top pane on the same monitor, instead of (or alongside) the hardware screen.

## What's included

**New overlay window (`gui/overlay_window.py`)**
- Frameless, semi-transparent, always-on-top window that renders translations in the Turing palette (player name / white original / green `→` / light-green translation; orange for team chat, purple for voice).
- Marked `WA_ShowWithoutActivating` and, on Windows, `WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW` so showing it — and even clicking its title bar to drag it — never pulls keyboard focus away from the game.
- Draggable title bar, `QSizeGrip` resize, opacity `–`/`+`, clear (`⌫`) and hide (`✕`) buttons.
- Consumes the same `on_translation` payloads the dashboard feed already receives — the translation engine is unaware of it.

**GUI wiring (`gui/main_window.py`, `gui/settings_store.py`)**
- New **Overlay** toggle in the header; feeds translations to the overlay.
- Persists/restores overlay visibility, geometry, and opacity across sessions.

**Run with no hardware (`src/config/config_manager.py`, `src/main.py`, `config/config.sample.json`, `gui/settings_tab.py`)**
- New `screen.enabled` config flag plus a **Use hardware Turing screen** toggle under Settings → Turing Screen.
- When disabled, the engine skips the serial connection entirely and only drives the overlay/live feed.
- An **absent** `screen.enabled` key defaults to enabled, so existing hardware setups are unaffected (and the Settings form won't silently disable a working screen on Save).

## Caveat

A game in **exclusive** (true) fullscreen paints over all top-most windows. Use borderless / windowed-fullscreen mode for the overlay to be visible — this is the common L4D2 setup. Documented in the README.

The overlay lives in the desktop GUI (`python gui_main.py`), where translations are already surfaced to the UI. The plain console app has no Qt loop, so it just runs hardware-free and logs.

## Testing

- Added tests covering overlay add/clear, max-row trimming, opacity persistence, and the `screen.enabled` default-on behaviour.
- Full GUI suite passes (`QT_QPA_PLATFORM=offscreen pytest tests/test_gui.py` → 11 passed).
- Verified `screen.enabled` parsing (present / absent → default true / false) and that all edited files compile.

Note: the engine's `src/tools/` tests error during collection in a minimal checkout due to a pre-existing missing `cachetools` dependency — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZNWNrzEvGi7PfvAxsJEwe)_