### PR TITLE
Fix overlay not updating and voice init when screen/voice disabled

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -205,10 +205,12 @@ class Left4Translate:
                 self.reader = None
                 
             # Initialize voice translation manager if mode is 'voice' or 'both'
-            if self.mode in ['voice', 'both']:
-                # Get the full config dictionary
-                config_dict = self.config_manager.get_config()
-                
+            # AND voice translation is enabled in config. Constructing the
+            # manager probes the microphone and validates speech-to-text
+            # credentials, so we skip it entirely when voice is disabled.
+            config_dict = self.config_manager.get_config()
+            voice_enabled = config_dict.get("voice_translation", {}).get("enabled", True)
+            if self.mode in ['voice', 'both'] and voice_enabled:
                 # Initialize voice translation manager
                 self.voice_manager = VoiceTranslationManager(
                     config=config_dict,
@@ -217,6 +219,10 @@ class Left4Translate:
                     on_translation_callback=self._handle_voice_translation
                 )
             else:
+                if self.mode in ['voice', 'both'] and not voice_enabled:
+                    self.logger.info(
+                        "Voice translation disabled in config - skipping initialization"
+                    )
                 self.voice_manager = None
                 
         except Exception as e:
@@ -254,14 +260,20 @@ class Left4Translate:
                 self.logger.error(f"Translation error: {e}")
                 translated = chat_message  # Use original message if translation fails
             
-            # Display message
-            self.screen.display_message(
-                player=player_name,
-                original=chat_message,
-                translated=translated,
-                is_team_chat=bool(team_type)  # True if team chat (Survivor/Infected)
-            )
-            
+            # Display message on the Turing screen (only when the hardware screen
+            # is enabled). This is best-effort: a screen error must never stop the
+            # translation from reaching observers (e.g. the GUI overlay/feed).
+            if self.screen_enabled:
+                try:
+                    self.screen.display_message(
+                        player=player_name,
+                        original=chat_message,
+                        translated=translated,
+                        is_team_chat=bool(team_type)  # True if team chat (Survivor/Infected)
+                    )
+                except Exception as e:
+                    self.logger.error(f"Error displaying message on screen: {e}")
+
             if translated != chat_message:
                 self.logger.info(f"Translated ({source_lang}): {translated}")
             else:
@@ -329,6 +341,9 @@ class Left4Translate:
                 else:
                     self.logger.error("Failed to start voice translation mode")
                     self._emit_status("voice", "error", "Voice translation failed to start")
+            elif self.mode in ['voice', 'both']:
+                # Voice requested by mode but disabled in config — not an error.
+                self._emit_status("voice", "idle", "Voice disabled")
 
             # Log the active modes
             if self.mode == 'both':

--- a/tests/test_engine_screen_voice.py
+++ b/tests/test_engine_screen_voice.py
@@ -1,0 +1,195 @@
+"""Regression tests for the headless engine (``src/main.py``).
+
+These cover two behaviours that broke when running without the Turing hardware:
+
+1. A chat message must still reach the ``on_translation`` observer (the GUI
+   overlay / live feed) even when the screen is disabled or its display call
+   raises — previously a screen error aborted ``_handle_message`` before the
+   translation was emitted.
+2. Voice translation must not be initialised at all when it's disabled in
+   config — constructing the manager probes the microphone and validates
+   speech-to-text credentials, which should not happen when voice is off.
+
+``src/main.py`` imports several heavy collaborators (Google Cloud, PIL, PyAudio)
+at module load, so we stub those modules before importing it. The engine's own
+logic under test is exercised against the real :class:`ConfigManager`.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+import types
+
+import pytest
+
+_SRC = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src")
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+
+class _FakeScreenController:
+    last_instance = None
+
+    def __init__(self, *args, **kwargs):
+        self.displayed = []
+        self.raise_on_display = False
+        _FakeScreenController.last_instance = self
+
+    def display_message(self, **kwargs):
+        if self.raise_on_display:
+            raise RuntimeError("Display not connected. Call connect() first.")
+        self.displayed.append(kwargs)
+
+    def connect(self):
+        return False
+
+    def disconnect(self):
+        pass
+
+
+class _FakeTranslationService:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def detect_language(self, text):
+        return "es"
+
+    def translate(self, text, source_language=None):
+        return f"EN:{text}"
+
+
+class _FakeVoiceManager:
+    instances = 0
+
+    def __init__(self, *args, **kwargs):
+        _FakeVoiceManager.instances += 1
+
+    def start(self):
+        return True
+
+    def stop(self):
+        pass
+
+
+class _FakeReader:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def start_monitoring(self, *args, **kwargs):
+        pass
+
+    def stop_monitoring(self):
+        pass
+
+
+class _FakeMessage:
+    def __init__(self, player, content, team=None):
+        self.player = player
+        self.content = content
+        self.team = team
+
+
+def _install_stub_modules():
+    """Stub the heavy modules ``main`` imports, then (re)import ``main``."""
+    reader_mod = types.ModuleType("reader.message_reader")
+    reader_mod.GameMessageReader = _FakeReader
+    reader_mod.Message = _FakeMessage
+
+    translator_mod = types.ModuleType("translator.translation_service")
+    translator_mod.TranslationService = _FakeTranslationService
+
+    display_mod = types.ModuleType("display.screen_controller")
+    display_mod.ScreenController = _FakeScreenController
+
+    audio_mod = types.ModuleType("audio.voice_translation_manager")
+    audio_mod.VoiceTranslationManager = _FakeVoiceManager
+
+    # Parent packages so the dotted imports resolve.
+    for pkg in ("reader", "translator", "display", "audio"):
+        sys.modules.setdefault(pkg, types.ModuleType(pkg))
+    sys.modules["reader.message_reader"] = reader_mod
+    sys.modules["translator.translation_service"] = translator_mod
+    sys.modules["display.screen_controller"] = display_mod
+    sys.modules["audio.voice_translation_manager"] = audio_mod
+
+    sys.modules.pop("main", None)
+    return importlib.import_module("main")
+
+
+@pytest.fixture
+def main_module():
+    return _install_stub_modules()
+
+
+def _write_config(tmp_path, *, screen_enabled, voice_enabled):
+    sample = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "config", "config.sample.json",
+    )
+    with open(sample, "r", encoding="utf-8") as fh:
+        cfg = json.load(fh)
+    cfg["translation"]["apiKey"] = "test-key"
+    cfg["screen"]["enabled"] = screen_enabled
+    cfg["voice_translation"]["enabled"] = voice_enabled
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps(cfg), encoding="utf-8")
+    return str(path)
+
+
+def _make_engine(main_module, config_path, mode, on_translation=None):
+    return main_module.Left4Translate(
+        config_path,
+        mode,
+        on_translation=on_translation,
+        on_status=lambda *a, **k: None,
+        install_signal_handlers=False,
+    )
+
+
+def test_message_emits_when_screen_disabled(main_module, tmp_path):
+    config_path = _write_config(tmp_path, screen_enabled=False, voice_enabled=False)
+    received = []
+    engine = _make_engine(main_module, config_path, "chat", on_translation=received.append)
+
+    engine._handle_message(_FakeMessage("Pug Wrangler", "hola", team="Survivor"))
+
+    assert len(received) == 1
+    assert received[0]["player"] == "Pug Wrangler"
+    assert received[0]["translated"] == "EN:hola"
+    # Screen disabled: nothing should have been pushed to the (fake) display.
+    assert _FakeScreenController.last_instance.displayed == []
+
+
+def test_message_emits_when_screen_display_raises(main_module, tmp_path):
+    config_path = _write_config(tmp_path, screen_enabled=True, voice_enabled=False)
+    received = []
+    engine = _make_engine(main_module, config_path, "chat", on_translation=received.append)
+    # Simulate the "Display not connected" failure on every render.
+    _FakeScreenController.last_instance.raise_on_display = True
+
+    engine._handle_message(_FakeMessage("Bob", "corre", team="Infected"))
+
+    # The screen error must not stop the translation from reaching the observer.
+    assert len(received) == 1
+    assert received[0]["translated"] == "EN:corre"
+
+
+def test_voice_manager_not_initialised_when_disabled(main_module, tmp_path):
+    _FakeVoiceManager.instances = 0
+    config_path = _write_config(tmp_path, screen_enabled=False, voice_enabled=False)
+    engine = _make_engine(main_module, config_path, "both")
+
+    assert engine.voice_manager is None
+    assert _FakeVoiceManager.instances == 0
+
+
+def test_voice_manager_initialised_when_enabled(main_module, tmp_path):
+    _FakeVoiceManager.instances = 0
+    config_path = _write_config(tmp_path, screen_enabled=False, voice_enabled=True)
+    engine = _make_engine(main_module, config_path, "both")
+
+    assert engine.voice_manager is not None
+    assert _FakeVoiceManager.instances == 1


### PR DESCRIPTION
## Summary

Follow-up to #13. Two issues showed up when running with the Turing screen disabled and voice translation turned off:

1. **Overlay stuck on "Waiting for translations".** With the hardware screen disabled, `screen.display_message()` raised `Display not connected. Call connect() first.` inside `_handle_message` — and that happened *before* the translation was emitted to observers. The exception was swallowed by the outer `try/except`, so the GUI overlay / live feed never received the message.

2. **Voice still initialising when disabled.** Even with `voice_translation.enabled: false`, the engine constructed `VoiceTranslationManager`, which probes the microphone and validates the speech-to-text credentials file. That produced the mic-volume test, the `Credentials file does not exist…` error, and a misleading `Failed to start voice translation mode` error.

## Changes (`src/main.py`)

- **Guard the screen display.** The `screen.display_message()` call is now only made when `screen_enabled` is true, and is wrapped in its own `try/except` that logs but does not propagate. The translation is emitted to observers regardless, so the overlay updates whether or not the screen is present/working.
- **Skip voice init when disabled.** `VoiceTranslationManager` is only constructed when `voice_translation.enabled` is true (and the mode includes voice). When voice is disabled it's left as `None`, so the mic is never probed and the credentials file is never read. `start()` now emits a clean `voice / idle / "Voice disabled"` status instead of an error.

## Testing

- New `tests/test_engine_screen_voice.py` (stubs the heavy Google/PIL/PyAudio collaborators so the engine logic runs headlessly) covering:
  - a chat message still reaches the `on_translation` observer when the screen is **disabled**,
  - …and when the screen's display call **raises**,
  - the voice manager is **not** constructed when voice is disabled,
  - …and **is** constructed when enabled.
- Full `tests/` suite: **15 passed** (`QT_QPA_PLATFORM=offscreen`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZNWNrzEvGi7PfvAxsJEwe)_