### PR TITLE
Guard voice translation screen display when Turing screen not connected

### DIFF
--- a/src/audio/voice_translation_manager.py
+++ b/src/audio/voice_translation_manager.py
@@ -311,17 +311,23 @@ class VoiceTranslationManager:
             logger.info("Copying to clipboard...")
             self.clipboard_manager.copy_to_clipboard(transcript, translated)
             
-            # Display on screen if screen controller is available
+            # Display on screen if a screen controller is available. This is
+            # best-effort: when the Turing screen isn't connected (e.g. running
+            # with the overlay only) display_message raises, and that must not
+            # stop the translation from reaching the callback below.
             if self.screen_controller:
                 logger.info("Displaying on screen...")
-                self.screen_controller.display_message(
-                    player="Voice",
-                    original=transcript,
-                    translated=translated,
-                    is_team_chat=False,
-                    timeout=self.clear_after if self.clear_after > 0 else None
-                )
-            
+                try:
+                    self.screen_controller.display_message(
+                        player="Voice",
+                        original=transcript,
+                        translated=translated,
+                        is_team_chat=False,
+                        timeout=self.clear_after if self.clear_after > 0 else None
+                    )
+                except Exception as e:
+                    logger.error(f"Error displaying voice translation on screen: {e}")
+
             # Call callback with results
             if self.on_translation_callback:
                 logger.info("Calling translation callback...")

--- a/tests/test_voice_screen_guard.py
+++ b/tests/test_voice_screen_guard.py
@@ -1,0 +1,106 @@
+"""Regression test for voice translation when the Turing screen isn't connected.
+
+``VoiceTranslationManager._process_audio`` displays the result on the Turing
+screen before invoking ``on_translation_callback``. When the screen is disabled
+or not connected, ``display_message`` raises ``Display not connected`` — that
+must not stop the translation from reaching the callback (the GUI overlay /
+clipboard).
+
+``voice_translation_manager`` imports several hardware/cloud collaborators at
+module load (PyAudio-backed recorder, pynput mouse handler, Google speech, …),
+so we stub those modules before importing it, and build the manager via
+``object.__new__`` to bypass the mic-probing constructor.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import types
+
+import pytest
+
+_SRC = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src")
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+
+def _stub(module_name: str, **attrs) -> None:
+    mod = types.ModuleType(module_name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    sys.modules[module_name] = mod
+
+
+class _RaisingScreen:
+    def display_message(self, **kwargs):
+        raise RuntimeError("Display not connected. Call connect() first.")
+
+
+class _SpeechToText:
+    client = object()
+    language_code = "en-US"
+
+    def transcribe_audio(self, audio_data):
+        return "hello", 0.95
+
+
+class _Translator:
+    def translate(self, text, source_language=None, target_language=None):
+        return "hola"
+
+
+class _Clipboard:
+    def __init__(self):
+        self.copied = []
+
+    def copy_to_clipboard(self, original, translated):
+        self.copied.append((original, translated))
+
+
+@pytest.fixture
+def manager_module():
+    # Make `audio` a package whose submodules resolve to the real source dir,
+    # so the real voice_translation_manager.py loads while its heavy siblings
+    # (and the heavy `audio/__init__.py`) are replaced by the stubs below.
+    audio_pkg = types.ModuleType("audio")
+    audio_pkg.__path__ = [os.path.join(_SRC, "audio")]
+    sys.modules["audio"] = audio_pkg
+    for parent in ("input", "translator", "utils"):
+        sys.modules[parent] = types.ModuleType(parent)
+
+    _stub("numpy")
+    _stub("input.mouse_handler", MouseHandler=object)
+    _stub("audio.voice_recorder", VoiceRecorder=object)
+    _stub("audio.speech_to_text", SpeechToTextService=object)
+    _stub("translator.translation_service", TranslationService=object)
+    _stub("utils.clipboard_manager", ClipboardManager=object)
+    sys.modules.pop("audio.voice_translation_manager", None)
+    return importlib.import_module("audio.voice_translation_manager")
+
+
+def _make_manager(manager_module, on_translation_callback):
+    mgr = object.__new__(manager_module.VoiceTranslationManager)
+    mgr.speech_to_text = _SpeechToText()
+    mgr.translation_service = _Translator()
+    mgr.clipboard_manager = _Clipboard()
+    mgr.screen_controller = _RaisingScreen()
+    mgr.on_translation_callback = on_translation_callback
+    mgr.target_language = "es"
+    mgr.clear_after = 5000
+    # Bypass the numpy-based audio check.
+    mgr._check_audio_quality = lambda audio_data: "good"
+    return mgr
+
+
+def test_voice_callback_fires_when_screen_raises(manager_module):
+    received = []
+    mgr = _make_manager(manager_module, lambda t, tr: received.append((t, tr)))
+
+    mgr._process_audio(b"\x00\x00")
+
+    # The screen failure must not prevent the callback (overlay/feed) from firing.
+    assert received == [("hello", "hola")]
+    # …and the clipboard copy should still have happened.
+    assert mgr.clipboard_manager.copied == [("hello", "hola")]


### PR DESCRIPTION
## Summary

Follow-up to #14 — the same "Display not connected" class of bug, now in the **voice** path.

`VoiceTranslationManager._process_audio` displays the result on the Turing screen *before* it invokes `on_translation_callback`. With the screen disabled or not connected, `display_message()` raises `Display not connected. Call connect() first.`, which aborted `_process_audio` — so a voice translation never reached the GUI overlay / live feed:

```
ERROR audio.voice_translation_manager: Error processing audio: Display not connected. Call connect() first.
  File "display/screen_controller.py", line 167, in _calculate_message_height
  File "display/turing_display.py", line 174, in font_bold
RuntimeError: Display not connected. Call connect() first.
```

(The clipboard copy runs *before* the screen display, so transcription itself worked — only the on-screen/overlay output and the callback were lost.)

## Change (`src/audio/voice_translation_manager.py`)

The screen display in `_process_audio` is now best-effort — wrapped in its own `try/except` that logs but doesn't propagate — so a screen failure can't stop the translation from reaching the callback (overlay/feed). The transcription-error path (`_show_transcription_error`) was already guarded this way.

## Testing

- New `tests/test_voice_screen_guard.py` (stubs the recorder / mouse / speech / clipboard collaborators and builds the manager via `object.__new__` to skip the mic-probing constructor): verifies that when the screen's `display_message` raises, `on_translation_callback` and the clipboard copy still fire.
- Full `tests/` suite: **16 passed** (`QT_QPA_PLATFORM=offscreen`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZNWNrzEvGi7PfvAxsJEwe)_