### PR TITLE
Fix random native crashes by running GC on GUI thread only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Unreleased
 
 ### Fixed
+- **Random native crash (access violation) during long GUI sessions**:
+  Python's cyclic garbage collector could run on an engine worker thread and
+  destroy Qt objects that belong to the GUI thread, corrupting Qt and killing
+  the process mid-translation (crash.log showed the fault inside the
+  dashboard feed's table update). Automatic GC is now disabled in the GUI and
+  collections run from a timer on the GUI thread instead (`gui/gc_guard.py`).
 - **Silent exits**: the GUI now installs global crash reporting — uncaught
   errors are written to `logs/app.log`, native faults (Qt, PortAudio, mouse
   hook, serial) to `logs/crash.log`, and an error dialog is shown instead of

--- a/gui/app.py
+++ b/gui/app.py
@@ -12,7 +12,7 @@ from PySide6.QtGui import QIcon
 from PySide6.QtNetwork import QLocalServer, QLocalSocket
 from PySide6.QtWidgets import QApplication, QMessageBox
 
-from gui import crash_guard
+from gui import crash_guard, gc_guard
 from gui.main_window import MainWindow
 from gui.settings_store import SettingsStore
 from gui.theme import apply_theme
@@ -134,6 +134,9 @@ def build_application(argv: Optional[Sequence[str]] = None) -> tuple[QApplicatio
     app = QApplication.instance() or QApplication(
         list(argv) if argv is not None else sys.argv
     )
+    # Cyclic GC must never run on the engine's worker threads (it would
+    # destroy Qt objects off the GUI thread → native access violation).
+    gc_guard.install(app)
     crash_guard.reporter.crashed.connect(_show_crash_dialog)
     app.setApplicationName(APP_NAME)
     app.setOrganizationName(ORG_NAME)

--- a/gui/gc_guard.py
+++ b/gui/gc_guard.py
@@ -1,0 +1,86 @@
+"""Run Python's cyclic garbage collector only on the GUI thread.
+
+CPython triggers a cyclic collection on whichever thread happens to trip the
+allocation threshold. In this app that is almost always one of the engine's
+worker threads — the watchdog log reader, the voice pipeline, the display
+loop — because they allocate constantly. When a collection running on such a
+thread frees a reference cycle that contains PySide6 wrappers, the underlying
+Qt C++ objects are destroyed *on that worker thread*. Qt requires GUI objects
+to be destroyed on the thread that owns them; destroying them elsewhere
+corrupts Qt's internal state, and the damage detonates later as a native
+access violation in unrelated GUI-thread code (observed in the field as a
+crash inside the dashboard feed's QTableWidget row churn — see
+``logs/crash.log`` in the bug report).
+
+The mitigation — used by calibre, Anki, and other large PyQt/PySide apps —
+is to disable the automatic collector and drive ``gc.collect()`` from a
+QTimer on the GUI thread, where deleting those wrappers is safe. Reference
+counting is unaffected: acyclic objects are still freed immediately, only
+reference *cycles* wait for the timer tick.
+"""
+
+from __future__ import annotations
+
+import gc
+from typing import Optional
+
+from PySide6.QtCore import QObject, QTimer
+
+# How often the GUI-thread collection runs, and how many ticks between full
+# (generation 2) collections. Young-generation passes are cheap (<1 ms); the
+# occasional full pass keeps long-lived cycles from accumulating.
+_INTERVAL_MS = 2000
+_FULL_EVERY = 15
+
+_instance: Optional["GcDriver"] = None
+
+
+class GcDriver(QObject):
+    """Owns the collection timer. Must be created on the GUI thread."""
+
+    def __init__(
+        self,
+        parent: Optional[QObject] = None,
+        interval_ms: int = _INTERVAL_MS,
+        full_every: int = _FULL_EVERY,
+    ) -> None:
+        super().__init__(parent)
+        self._full_every = max(1, full_every)
+        self._tick = 0
+        self._timer = QTimer(self)
+        self._timer.setInterval(interval_ms)
+        self._timer.timeout.connect(self._collect)
+
+    def start(self) -> None:
+        gc.disable()
+        self._timer.start()
+
+    def stop(self) -> None:
+        self._timer.stop()
+        gc.enable()
+
+    def _collect(self) -> None:
+        self._tick = (self._tick + 1) % self._full_every
+        # Generation 1 also sweeps generation 0; generation 2 sweeps everything.
+        gc.collect(2 if self._tick == 0 else 1)
+
+
+def install(parent: Optional[QObject] = None) -> GcDriver:
+    """Disable automatic GC and start GUI-thread collections. Idempotent.
+
+    Call on the GUI thread after the QApplication exists (the timer needs a
+    running event loop to fire, and must have GUI-thread affinity).
+    """
+    global _instance
+    if _instance is None:
+        _instance = GcDriver(parent)
+        _instance.start()
+    return _instance
+
+
+def uninstall() -> None:
+    """Stop the driver and restore automatic GC (used by tests)."""
+    global _instance
+    if _instance is not None:
+        _instance.stop()
+        _instance = None

--- a/tests/test_gc_guard.py
+++ b/tests/test_gc_guard.py
@@ -1,0 +1,77 @@
+"""Tests for gui.gc_guard — GUI-thread-only cyclic garbage collection.
+
+The guard exists to stop CPython's cyclic collector from running on engine
+worker threads, where freeing a cycle that contains PySide6 wrappers destroys
+Qt objects off the GUI thread and corrupts Qt (native access violation in the
+dashboard feed). These tests pin the contract: automatic GC is off while the
+guard is installed, the timer tick still reclaims cycles, and uninstall
+restores the interpreter default.
+"""
+
+from __future__ import annotations
+
+import gc
+import os
+import weakref
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+pytest.importorskip("PySide6")
+
+from PySide6.QtWidgets import QApplication  # noqa: E402
+
+from gui import gc_guard  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def app():
+    application = QApplication.instance() or QApplication([])
+    yield application
+
+
+@pytest.fixture()
+def guard(app):
+    driver = gc_guard.install(app)
+    yield driver
+    gc_guard.uninstall()
+    assert gc.isenabled()  # uninstall must always restore the default
+
+
+def test_install_disables_automatic_gc(guard):
+    assert not gc.isenabled()
+
+
+def test_install_is_idempotent(guard, app):
+    assert gc_guard.install(app) is guard
+
+
+def test_timer_runs_on_expected_interval(guard):
+    assert guard._timer.isActive()
+    assert guard._timer.interval() == gc_guard._INTERVAL_MS
+
+
+def test_tick_collects_reference_cycles(guard):
+    class Node:
+        pass
+
+    a, b = Node(), Node()
+    a.other, b.other = b, a  # unreachable cycle: refcounting alone can't free it
+    ref = weakref.ref(a)
+    del a, b
+
+    guard._collect()  # what the QTimer runs each tick
+    assert ref() is None
+
+
+def test_full_collection_every_nth_tick(guard, monkeypatch):
+    generations = []
+    monkeypatch.setattr(gc, "collect", lambda gen: generations.append(gen))
+
+    guard._tick = 0
+    for _ in range(gc_guard._FULL_EVERY):
+        guard._collect()
+
+    assert generations.count(2) == 1  # exactly one full pass per cycle
+    assert set(generations) <= {1, 2}


### PR DESCRIPTION
## Summary
Fixes random native access violations that occur during long GUI sessions by preventing Python's cyclic garbage collector from running on engine worker threads, where it could destroy Qt objects off the GUI thread and corrupt Qt's internal state.

## Changes
- **New module `gui/gc_guard.py`**: Implements a `GcDriver` class that disables automatic garbage collection and runs `gc.collect()` on a timer from the GUI thread instead. This ensures that reference cycles containing PySide6 wrappers are only freed on the thread that owns them.
  - Disables automatic GC on startup via `install()`
  - Runs young-generation collections every 2 seconds (cheap, <1ms)
  - Runs full generation-2 collections every 30 seconds to prevent long-lived cycles from accumulating
  - Restores automatic GC on `uninstall()` (for testing)

- **New test module `tests/test_gc_guard.py`**: Comprehensive test coverage verifying:
  - Automatic GC is disabled when the guard is installed
  - The timer runs at the expected interval
  - Reference cycles are properly collected
  - Full collections occur at the correct frequency
  - Idempotency of the install function

- **Updated `gui/app.py`**: Calls `gc_guard.install(app)` during application initialization to enable the guard before any worker threads start allocating.

- **Updated `CHANGELOG.md`**: Documents the fix for the random crash issue.

## Implementation Details
The mitigation follows the pattern used by large PyQt/PySide applications like calibre and Anki. By driving garbage collection from the GUI thread via QTimer, we ensure that destroying Qt C++ objects (which happens when reference cycles are freed) always occurs on the correct thread. Reference counting remains unaffected—acyclic objects are still freed immediately; only reference cycles wait for the timer tick.

https://claude.ai/code/session_01WfYD93cMoCryXmMNYxwbYS