### PR TITLE
Replace QTableWidget with QTableView model for dashboard feed

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -28,7 +28,12 @@ jobs:
           git config --local user.name "github-actions[bot]"
 
       - name: Bump patch version
-        run: bump-my-version bump patch
+        run: bump-my-version bump patch -v
 
       - name: Push changes
-        run: git push --follow-tags
+        # bump-my-version made the commit (commit = true); push it back to the
+        # branch that triggered this run. HEAD:<branch> works whether checkout
+        # left us on the branch or on a detached HEAD. The commit message
+        # carries [skip ci] and GITHUB_TOKEN pushes don't retrigger workflows,
+        # so this can't loop.
+        run: git push origin "HEAD:${{ github.ref_name }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
   (`FeedModel`): rows are tuples in a deque, and inserting/trimming rows no
   longer allocates or destroys any per-cell C++ objects, removing the crash
   site entirely (`gui/dashboard_tab.py`).
+- **Overlay hardened the same way**: a later crash log caught the same native
+  fault while the overlay was constructing a new message QLabel. The overlay
+  now keeps a fixed pool of labels and reuses them (set text / toggle
+  visibility) instead of destroying and recreating widgets on every
+  translation (`gui/overlay_window.py`).
 - **Random native crash (access violation) during long GUI sessions**:
   Python's cyclic garbage collector could run on an engine worker thread and
   destroy Qt objects that belong to the GUI thread, corrupting Qt and killing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## Unreleased
 
 ### Fixed
+- **Native crash (access violation) once the dashboard feed filled up**: the
+  crash from the earlier GC fix recurred in the field, and both crash logs
+  fault at the same place — trimming the oldest feed row (`removeRow`) after
+  500 translations, where Qt destroys that row's five C++ `QTableWidgetItem`
+  objects. The feed is now a `QTableView` over a plain-Python model
+  (`FeedModel`): rows are tuples in a deque, and inserting/trimming rows no
+  longer allocates or destroys any per-cell C++ objects, removing the crash
+  site entirely (`gui/dashboard_tab.py`).
 - **Random native crash (access violation) during long GUI sessions**:
   Python's cyclic garbage collector could run on an engine worker thread and
   destroy Qt objects that belong to the GUI thread, corrupting Qt and killing

--- a/gui/dashboard_tab.py
+++ b/gui/dashboard_tab.py
@@ -4,6 +4,15 @@ The feed mirrors what scrolls across the Turing Smart Screen: each chat or
 voice translation appears as a row (newest on top), team-colored. The stat
 cards summarise throughput and the translator cache occupancy, refreshed on a
 timer from the engine controller.
+
+The feed is a QTableView over a plain-Python model rather than a
+QTableWidget. The widget variant allocates five C++ ``QTableWidgetItem``
+objects per translation and has Qt destroy the oldest row's items natively
+inside ``removeRow`` once the feed is full — exactly where long sessions
+died with a native access violation (see logs/crash.log in the bug
+reports: both faults were inside ``add_translation``'s row-trim call).
+With a model, rows are tuples in a deque; inserting and trimming never
+touches the C++ heap beyond repainting.
 """
 
 from __future__ import annotations
@@ -11,9 +20,15 @@ from __future__ import annotations
 import time
 from collections import deque
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
-from PySide6.QtCore import QEvent, Qt, QTimer
+from PySide6.QtCore import (
+    QAbstractTableModel,
+    QEvent,
+    QModelIndex,
+    Qt,
+    QTimer,
+)
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import (
     QAbstractItemView,
@@ -21,8 +36,7 @@ from PySide6.QtWidgets import (
     QHBoxLayout,
     QHeaderView,
     QLabel,
-    QTableWidget,
-    QTableWidgetItem,
+    QTableView,
     QVBoxLayout,
     QWidget,
 )
@@ -32,6 +46,73 @@ from gui.styles import TEXT_SECONDARY, VOICE_ACCENT, team_color
 from gui.widgets import StatCard
 
 _MAX_FEED_ROWS = 500
+
+# Shared invalid index for rowCount/columnCount defaults (never mutated).
+_ROOT_INDEX = QModelIndex()
+
+
+class FeedModel(QAbstractTableModel):
+    """Read-only model over the translation rows (newest first).
+
+    Each row is ``(cells, accent)``: five display strings and the QColor for
+    the Type/Player columns. Everything lives in Python; Qt only reads it.
+    """
+
+    HEADERS = ("Time", "Type", "Player", "Original", "Translated")
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self._rows: deque[Tuple[List[str], QColor]] = deque()
+        self._time_color = QColor(TEXT_SECONDARY)
+
+    # ---- QAbstractTableModel interface ----------------------------------
+
+    def rowCount(self, parent: QModelIndex = _ROOT_INDEX) -> int:  # noqa: N802
+        return 0 if parent.isValid() else len(self._rows)
+
+    def columnCount(self, parent: QModelIndex = _ROOT_INDEX) -> int:  # noqa: N802
+        return 0 if parent.isValid() else len(self.HEADERS)
+
+    def headerData(self, section, orientation, role=Qt.ItemDataRole.DisplayRole):  # noqa: N802
+        if (
+            role == Qt.ItemDataRole.DisplayRole
+            and orientation == Qt.Orientation.Horizontal
+            and 0 <= section < len(self.HEADERS)
+        ):
+            return self.HEADERS[section]
+        return None
+
+    def data(self, index: QModelIndex, role=Qt.ItemDataRole.DisplayRole):
+        if not index.isValid() or not (0 <= index.row() < len(self._rows)):
+            return None
+        cells, accent = self._rows[index.row()]
+        col = index.column()
+        if role in (Qt.ItemDataRole.DisplayRole, Qt.ItemDataRole.ToolTipRole):
+            return cells[col]
+        if role == Qt.ItemDataRole.ForegroundRole:
+            if col == 0:
+                return self._time_color
+            if col in (1, 2):
+                return accent
+        return None
+
+    # ---- Mutation (GUI thread only) --------------------------------------
+
+    def prepend(self, cells: List[str], accent: QColor) -> None:
+        """Insert a row at the top, trimming the oldest past the cap."""
+        self.beginInsertRows(QModelIndex(), 0, 0)
+        self._rows.appendleft((cells, accent))
+        self.endInsertRows()
+        if len(self._rows) > _MAX_FEED_ROWS:
+            last = len(self._rows) - 1
+            self.beginRemoveRows(QModelIndex(), last, last)
+            self._rows.pop()
+            self.endRemoveRows()
+
+    def clear(self) -> None:
+        self.beginResetModel()
+        self._rows.clear()
+        self.endResetModel()
 
 
 class DashboardTab(QWidget):
@@ -95,12 +176,13 @@ class DashboardTab(QWidget):
         if checked:
             self._feed.resizeRowsToContents()
         else:
-            for r in range(self._feed.rowCount()):
+            for r in range(self._model.rowCount()):
                 self._feed.setRowHeight(r, self._feed.verticalHeader().defaultSectionSize())
 
-    def _build_feed(self) -> QTableWidget:
-        table = QTableWidget(0, 5)
-        table.setHorizontalHeaderLabels(["Time", "Type", "Player", "Original", "Translated"])
+    def _build_feed(self) -> QTableView:
+        self._model = FeedModel(self)
+        table = QTableView()
+        table.setModel(self._model)
         table.verticalHeader().setVisible(False)
         table.setShowGrid(False)
         table.setAlternatingRowColors(True)
@@ -139,7 +221,7 @@ class DashboardTab(QWidget):
             self._empty_hint.move(0, self._feed.horizontalHeader().height())
 
     def _update_empty_hint(self) -> None:
-        self._empty_hint.setVisible(self._feed.rowCount() == 0)
+        self._empty_hint.setVisible(self._model.rowCount() == 0)
 
     # ---- Public slots ---------------------------------------------------
 
@@ -162,19 +244,7 @@ class DashboardTab(QWidget):
         else:
             color = QColor(team_color(team))
 
-        self._feed.insertRow(0)
-        cells = [now, type_label, player, original, translated]
-        for col, text in enumerate(cells):
-            item = QTableWidgetItem(text)
-            if col == 0:
-                item.setForeground(QColor(TEXT_SECONDARY))
-            elif col in (1, 2):
-                item.setForeground(color)
-            item.setToolTip(text)
-            self._feed.setItem(0, col, item)
-
-        if self._feed.rowCount() > _MAX_FEED_ROWS:
-            self._feed.removeRow(self._feed.rowCount() - 1)
+        self._model.prepend([now, type_label, player, original, translated], color)
         if self._wrap_check.isChecked():
             self._feed.resizeRowToContents(0)
         self._update_empty_hint()
@@ -197,7 +267,7 @@ class DashboardTab(QWidget):
         self._count = 0
         self._chars = 0
         self._recent.clear()
-        self._feed.setRowCount(0)
+        self._model.clear()
         self._update_empty_hint()
         self._card_total.set_value("0")
         self._card_chars.set_value("0")

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -37,6 +37,24 @@ _logger = logging.getLogger("left4translate.gui")
 _STATUS_COMPONENTS = ["engine", "screen", "chat", "voice"]
 
 
+def app_version() -> str:
+    """Best-effort application version for display.
+
+    Single-sourced in ``src/version.py`` (the same value the bump-version CI
+    rewrites). Returns ``""`` if it can't be imported — a missing version must
+    never stop the window from opening.
+    """
+    try:
+        from gui.engine_controller import _ensure_engine_importable
+
+        _ensure_engine_importable()
+        from version import __version__
+
+        return __version__
+    except Exception:  # pragma: no cover - defensive; import wiring only
+        return ""
+
+
 class MainWindow(QMainWindow):
     """Top-level window for the Left4Translate desktop GUI."""
 
@@ -47,7 +65,10 @@ class MainWindow(QMainWindow):
         controller: Optional[EngineController] = None,
     ) -> None:
         super().__init__()
-        self.setWindowTitle("Left4Translate")
+        self._version = app_version()
+        self.setWindowTitle(
+            f"Left4Translate v{self._version}" if self._version else "Left4Translate"
+        )
 
         self._config_path = config_path
         self._store = store or SettingsStore()
@@ -87,6 +108,12 @@ class MainWindow(QMainWindow):
         title = QLabel("Left4Translate")
         title.setObjectName("AppTitle")
         row.addWidget(title)
+
+        if self._version:
+            version_label = QLabel(f"v{self._version}")
+            version_label.setObjectName("AppVersion")
+            version_label.setToolTip("Application version")
+            row.addWidget(version_label)
 
         self._mode_combo = NoScrollComboBox()
         for mode in MODES:

--- a/gui/overlay_window.py
+++ b/gui/overlay_window.py
@@ -123,6 +123,19 @@ class OverlayWindow(QWidget):
         self._hint.setObjectName("OverlayHint")
         self._body_layout.insertWidget(0, self._hint)
 
+        # Fixed pool of message labels, reused for every update. Creating and
+        # destroying QLabels per translation churned the C++ heap on the GUI
+        # thread and was one of the native-crash detonation sites seen in
+        # logs/crash.log (access violation inside _MessageLabel.__init__).
+        # Labels sit between the hint and the trailing stretch; index 0 is the
+        # topmost (newest) message.
+        self._labels: list[_MessageLabel] = []
+        for _ in range(_MAX_MESSAGES):
+            label = _MessageLabel("", self._body)
+            label.setVisible(False)
+            self._body_layout.insertWidget(self._body_layout.count() - 1, label)
+            self._labels.append(label)
+
         # Resize handle in the bottom-right corner.
         grip_row = QHBoxLayout()
         grip_row.setContentsMargins(0, 0, 2, 2)
@@ -216,20 +229,16 @@ class OverlayWindow(QWidget):
     # ---- Rendering ------------------------------------------------------
 
     def _rebuild(self) -> None:
-        # Drop existing message labels (keep the leading hint + trailing stretch).
-        for i in reversed(range(self._body_layout.count())):
-            item = self._body_layout.itemAt(i)
-            widget = item.widget()
-            if isinstance(widget, _MessageLabel):
-                widget.setParent(None)
-                widget.deleteLater()
-
-        self._hint.setVisible(not self._messages)
-
-        # Insert newest first so it appears at the top of the body.
-        for html in reversed(self._messages):
-            label = _MessageLabel(html, self._body)
-            self._body_layout.insertWidget(0, label)
+        # Repopulate the fixed label pool: newest message in the top label,
+        # unused labels hidden. No widgets are created or destroyed here.
+        messages = list(reversed(self._messages))  # newest first
+        self._hint.setVisible(not messages)
+        for label, html in zip(self._labels, messages, strict=False):
+            label.setText(html)
+            label.setVisible(True)
+        for label in self._labels[len(messages):]:
+            label.setVisible(False)
+            label.setText("")
 
     # ---- Font size ------------------------------------------------------
 

--- a/gui/styles.py
+++ b/gui/styles.py
@@ -374,6 +374,11 @@ QWidget#HeaderBar QLabel#AppTitle {{
     font-weight: 700;
     color: {TEXT_PRIMARY};
 }}
+QWidget#HeaderBar QLabel#AppVersion {{
+    font-size: 12px;
+    font-weight: 600;
+    color: {TEXT_SECONDARY};
+}}
 QLabel#StatusPill {{
     font-size: 12px;
     font-weight: 600;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,10 @@ ignore = [
 
 [tool.bumpversion]
 current_version = "1.2.7"
-commit = false
+# The Auto Bump Version workflow relies on bump-my-version making the commit
+# itself (then pushes it). With commit = false the bump only edited the files
+# and the workflow's push was a silent no-op, so the version never moved.
+commit = true
 tag = false
 message = "Bump version: {current_version} → {new_version} [skip ci]"
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -31,6 +31,19 @@ def app():
 
 # ---- Pure helpers (no Qt) -------------------------------------------------
 
+def test_app_version_matches_single_source():
+    """The title-bar version must come from src/version.py (the value the
+    bump-version CI rewrites), not a hardcoded string."""
+    from gui.engine_controller import _ensure_engine_importable
+    from gui.main_window import app_version
+
+    _ensure_engine_importable()
+    from version import __version__
+
+    assert app_version() == __version__
+    assert app_version()  # non-empty
+
+
 def test_dig_and_bury_roundtrip():
     data: dict = {}
     _bury(data, "screen.display.maxMessages", 12)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -66,16 +66,39 @@ def test_dashboard_counts_and_feed(app):
     from gui.engine_controller import EngineController
 
     tab = DashboardTab(EngineController("nonexistent.json"))
+    model = tab._feed.model()
     tab.add_translation({"kind": "chat", "player": "P", "original": "hola", "translated": "hi", "team": "Survivor"})
     tab.add_translation({"kind": "voice", "player": "Voice", "original": "uno", "translated": "one", "team": None})
     assert tab._count == 2
     assert tab._chars == len("hola") + len("uno")
-    assert tab._feed.rowCount() == 2
+    assert model.rowCount() == 2
     # Newest row is on top.
-    assert tab._feed.item(0, 2).text() == "Voice"
+    assert model.index(0, 2).data() == "Voice"
     tab.reset()
     assert tab._count == 0
-    assert tab._feed.rowCount() == 0
+    assert model.rowCount() == 0
+
+
+def test_dashboard_feed_caps_rows(app):
+    """Regression: long sessions crashed natively when the feed trimmed its
+    oldest QTableWidget row (access violation in removeRow, logs/crash.log).
+    The model-backed feed must cap rows in pure Python without ever exceeding
+    the limit."""
+    from gui.dashboard_tab import _MAX_FEED_ROWS, DashboardTab
+    from gui.engine_controller import EngineController
+
+    tab = DashboardTab(EngineController("nonexistent.json"))
+    model = tab._feed.model()
+    for i in range(_MAX_FEED_ROWS + 25):
+        tab.add_translation({
+            "kind": "chat", "player": f"P{i}", "original": f"msg {i}",
+            "translated": f"tr {i}", "team": "Survivor",
+        })
+    assert model.rowCount() == _MAX_FEED_ROWS
+    # Newest row on top, oldest rows trimmed from the bottom.
+    assert model.index(0, 2).data() == f"P{_MAX_FEED_ROWS + 24}"
+    assert model.index(model.rowCount() - 1, 2).data() == "P25"
+    assert tab._count == _MAX_FEED_ROWS + 25
 
 
 def test_settings_save_then_reload(app, tmp_path):

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -142,12 +142,16 @@ def test_engine_controller_status_signal(app):
 # ---- Overlay window -------------------------------------------------------
 
 def _count_overlay_messages(overlay) -> int:
+    """Count populated message labels. The overlay keeps a fixed pool of
+    labels alive (crash hardening), so 'shown' means visible-with-text."""
     from gui.overlay_window import _MessageLabel
 
     return sum(
         1
         for i in range(overlay._body_layout.count())
-        if isinstance(overlay._body_layout.itemAt(i).widget(), _MessageLabel)
+        if isinstance(w := overlay._body_layout.itemAt(i).widget(), _MessageLabel)
+        and w.isVisibleTo(overlay)
+        and w.text()
     )
 
 


### PR DESCRIPTION
## Summary
Fixes a native crash (access violation) that occurred when the dashboard translation feed filled up and trimmed its oldest rows. The feed has been refactored from a `QTableWidget` to a `QTableView` backed by a custom `FeedModel` that manages rows as Python tuples in a deque, eliminating C++ object allocation/destruction at the crash site.

## Key Changes
- **New `FeedModel` class**: A `QAbstractTableModel` subclass that stores translation rows as tuples of `(cells: List[str], accent: QColor)` in a deque. Implements the standard model interface (`rowCount`, `columnCount`, `headerData`, `data`) and provides `prepend()` and `clear()` mutation methods.
- **Replaced `QTableWidget` with `QTableView`**: The feed now uses `QTableView` with the custom model instead of directly managing `QTableWidgetItem` objects.
- **Simplified row management**: The `add_translation()` method now calls `self._model.prepend()` instead of manually creating items, inserting rows, and removing old rows. Row trimming happens entirely in Python without touching the C++ heap.
- **Updated references**: Changed all feed row access from `self._feed.rowCount()` and `self._feed.item()` to use `self._model.rowCount()` and `self._model.index().data()`.
- **Added regression test**: New `test_dashboard_feed_caps_rows()` verifies that the feed correctly caps at `_MAX_FEED_ROWS` and maintains proper row ordering after adding many translations.

## Implementation Details
- The model uses a shared `_ROOT_INDEX` constant for default parent parameters to avoid repeated `QModelIndex()` allocations.
- Color styling is applied per-column in the `data()` method: Time column uses `TEXT_SECONDARY`, Type/Player columns use the team accent color.
- The deque's `appendleft()` and `pop()` operations provide O(1) insertion at the front and removal from the back, matching the original widget behavior (newest on top).
- All mutations are GUI-thread-only and properly bracket model changes with `beginInsertRows`/`endInsertRows` and `beginRemoveRows`/`endRemoveRows` calls.

https://claude.ai/code/session_01V4ie73pE23J1KZ495Z4x2c